### PR TITLE
change Readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Usage of gtran:
   -text string
         translate source text
 
-$ gtran -text "海賊王におれはなる"
+$ gtran -source=ja -target=en -text "海賊王におれはなる"
 Become a Pirate King
 
-$ gtran -source=en -target=ja -text="Become a Pirate King"
+$ gtran -text="Become a Pirate King"
 海賊王になる
 ```


### PR DESCRIPTION
default setting is "-source=en -target=ja". 
I use 'gtran -text "海賊王におれはなる"' than I get "海賊王に俺はなる".